### PR TITLE
Implement backend API client and robot control wiring

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,7 @@ class TeleTableApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthProvider(prefs, apiService)),
-        ChangeNotifierProvider(create: (_) => RobotControlProvider()),
+        ChangeNotifierProvider(create: (_) => RobotControlProvider(apiService)),
         ChangeNotifierProvider(create: (_) => DiaryProvider(apiService)),
       ],
       child: Consumer<AuthProvider>(

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -11,6 +11,7 @@ class AuthProvider with ChangeNotifier {
   String? _email;
   String? _userId;
   String? _token;
+  String _role = 'viewer';
   String? _errorMessage;
 
   AuthProvider(this._prefs, this._apiService) {
@@ -22,6 +23,10 @@ class AuthProvider with ChangeNotifier {
   String? get email => _email;
   String? get userId => _userId;
   String? get token => _token;
+  String get role => _role;
+  bool get isAdmin => _role == 'admin';
+  bool get isOperator => _role == 'operator';
+  bool get isViewer => _role == 'viewer';
   String? get errorMessage => _errorMessage;
 
   Future<void> _loadAuthState() async {
@@ -30,6 +35,7 @@ class AuthProvider with ChangeNotifier {
     _email = _prefs.getString('email');
     _userId = _prefs.getString('userId');
     _token = _prefs.getString('token');
+    _role = _prefs.getString('role') ?? 'viewer';
     
     // Initialize API service and load token
     await _apiService.init();
@@ -41,6 +47,7 @@ class AuthProvider with ChangeNotifier {
         _username = userInfo['name'] as String;
         _email = userInfo['email'] as String;
         _userId = userInfo['id'] as String;
+        _role = userInfo['role'] as String? ?? 'viewer';
       } catch (e) {
         debugPrint('Token invalid, logging out: $e');
         await logout();
@@ -75,12 +82,14 @@ class AuthProvider with ChangeNotifier {
       _email = userInfo['email'] as String;
       _userId = userInfo['id'] as String;
       _token = token;
+      _role = userInfo['role'] as String? ?? 'viewer';
       
       await _prefs.setBool('isAuthenticated', true);
       await _prefs.setString('username', _username!);
       await _prefs.setString('email', _email!);
       await _prefs.setString('userId', _userId!);
       await _prefs.setString('token', token);
+      await _prefs.setString('role', _role);
       
       notifyListeners();
       return true;
@@ -99,6 +108,7 @@ class AuthProvider with ChangeNotifier {
     _userId = null;
     _token = null;
     _errorMessage = null;
+    _role = 'viewer';
     
     await _apiService.clearToken();
     
@@ -107,6 +117,7 @@ class AuthProvider with ChangeNotifier {
     await _prefs.remove('email');
     await _prefs.remove('userId');
     await _prefs.remove('token');
+    await _prefs.remove('role');
     
     notifyListeners();
   }

--- a/lib/providers/robot_control_provider.dart
+++ b/lib/providers/robot_control_provider.dart
@@ -1,98 +1,187 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
+
+import '../services/api_service.dart';
 
 enum RobotMode { manual, automatic }
 
 class RobotControlProvider with ChangeNotifier {
+  final ApiService _apiService;
+
+  RobotControlProvider(this._apiService);
+
   RobotMode _currentMode = RobotMode.manual;
   bool _isConnected = false;
   double _joystickX = 0.0;
   double _joystickY = 0.0;
   double _speed = 50.0;
-  
-  // Getters
+  String? _error;
+  Map<String, dynamic>? _status;
+  String? _manualLockMessage;
+
+  WebSocket? _manualSocket;
+  StreamSubscription<dynamic>? _manualSocketSubscription;
+
   RobotMode get currentMode => _currentMode;
   bool get isConnected => _isConnected;
   double get joystickX => _joystickX;
   double get joystickY => _joystickY;
   double get speed => _speed;
-  
-  // Mode switching
-  void switchMode(RobotMode mode) {
-    if (_currentMode != mode) {
-      _currentMode = mode;
-      notifyListeners();
-      // TODO: Send mode change command to robot
-      _sendModeCommand(mode);
+  String? get error => _error;
+  Map<String, dynamic>? get status => _status;
+  String? get manualLockMessage => _manualLockMessage;
+
+  Future<void> switchMode(RobotMode mode) async {
+    if (_currentMode == mode) {
+      return;
     }
+
+    _currentMode = mode;
+    notifyListeners();
+    await _sendModeCommand(mode);
   }
-  
-  void toggleMode() {
-    switchMode(_currentMode == RobotMode.manual 
-        ? RobotMode.automatic 
-        : RobotMode.manual);
+
+  Future<void> toggleMode() async {
+    await switchMode(
+      _currentMode == RobotMode.manual ? RobotMode.automatic : RobotMode.manual,
+    );
   }
-  
-  // Joystick control
-  void updateJoystick(double x, double y) {
+
+  Future<void> updateJoystick(double x, double y) async {
     _joystickX = x;
     _joystickY = y;
     notifyListeners();
-    
+
     if (_currentMode == RobotMode.manual) {
-      // TODO: Send joystick commands to robot
-      _sendMovementCommand(x, y);
+      await _sendMovementCommand(x, y);
     }
   }
-  
-  // Speed control
-  void updateSpeed(double newSpeed) {
+
+  Future<void> updateSpeed(double newSpeed) async {
     _speed = newSpeed.clamp(0.0, 100.0);
     notifyListeners();
-    // TODO: Send speed command to robot
-    _sendSpeedCommand(_speed);
   }
-  
-  // Connection management
-  void connect() {
-    // TODO: Implement actual robot connection
-    _isConnected = true;
+
+  Future<void> loadStatus() async {
+    try {
+      _error = null;
+      _status = await _apiService.getRobotStatus();
+    } catch (e) {
+      _error = e.toString().replaceAll('Exception: ', '');
+    }
     notifyListeners();
   }
-  
-  void disconnect() {
+
+  Future<void> connect() async {
+    try {
+      _error = null;
+
+      final lockResult = await _apiService.acquireDriveLock();
+      _manualLockMessage = lockResult['message'] as String?;
+      if (lockResult['status'] != 'success') {
+        _isConnected = false;
+        notifyListeners();
+        return;
+      }
+
+      _manualSocket = await _apiService.connectManualDriveWebSocket();
+      _manualSocketSubscription = _manualSocket!.listen(
+        (_) {},
+        onError: (_) {
+          _isConnected = false;
+          notifyListeners();
+        },
+        onDone: () {
+          _isConnected = false;
+          notifyListeners();
+        },
+      );
+
+      _isConnected = true;
+      notifyListeners();
+    } catch (e) {
+      _error = e.toString().replaceAll('Exception: ', '');
+      _isConnected = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> disconnect() async {
+    try {
+      _error = null;
+
+      if (_manualSocket != null) {
+        await _manualSocket!.close();
+      }
+      await _manualSocketSubscription?.cancel();
+      _manualSocket = null;
+      _manualSocketSubscription = null;
+
+      await _apiService.releaseDriveLock();
+    } catch (e) {
+      _error = e.toString().replaceAll('Exception: ', '');
+    }
+
     _isConnected = false;
     _joystickX = 0.0;
     _joystickY = 0.0;
     notifyListeners();
   }
-  
-  // Emergency stop
-  void emergencyStop() {
+
+  Future<void> emergencyStop() async {
     _joystickX = 0.0;
     _joystickY = 0.0;
     notifyListeners();
-    // TODO: Send emergency stop command to robot
-    _sendEmergencyStopCommand();
+    await _sendEmergencyStopCommand();
   }
-  
-  // Private methods for robot communication
-  void _sendModeCommand(RobotMode mode) {
-    debugPrint('Sending mode command: ${mode.name}');
-    // TODO: Implement actual robot communication
+
+  Future<void> _sendModeCommand(RobotMode mode) async {
+    if (_manualSocket == null) {
+      return;
+    }
+
+    final command = {
+      'command': 'SET_MODE',
+      'mode': mode == RobotMode.manual ? 'MANUAL' : 'AUTONOMOUS',
+    };
+
+    await _apiService.sendManualCommand(_manualSocket!, command);
   }
-  
-  void _sendMovementCommand(double x, double y) {
-    debugPrint('Sending movement command: x=$x, y=$y');
-    // TODO: Implement actual robot communication
+
+  Future<void> _sendMovementCommand(double x, double y) async {
+    if (_manualSocket == null) {
+      return;
+    }
+
+    final speedScale = _speed / 100.0;
+    final command = {
+      'command': 'DRIVE_COMMAND',
+      'linear_velocity': y * speedScale,
+      'angular_velocity': x * speedScale,
+    };
+
+    await _apiService.sendManualCommand(_manualSocket!, command);
   }
-  
-  void _sendSpeedCommand(double speed) {
-    debugPrint('Sending speed command: $speed');
-    // TODO: Implement actual robot communication
+
+  Future<void> _sendEmergencyStopCommand() async {
+    if (_manualSocket == null) {
+      return;
+    }
+
+    final command = {
+      'command': 'DRIVE_COMMAND',
+      'linear_velocity': 0.0,
+      'angular_velocity': 0.0,
+    };
+
+    await _apiService.sendManualCommand(_manualSocket!, command);
   }
-  
-  void _sendEmergencyStopCommand() {
-    debugPrint('Sending emergency stop command');
-    // TODO: Implement actual robot communication
+
+  @override
+  void dispose() {
+    unawaited(disconnect());
+    super.dispose();
   }
 }

--- a/lib/screens/control_screen.dart
+++ b/lib/screens/control_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
@@ -59,9 +60,9 @@ class _ControlScreenState extends State<ControlScreen> {
                         ElevatedButton(
                           onPressed: () {
                             if (robotProvider.isConnected) {
-                              robotProvider.disconnect();
+                              unawaited(robotProvider.disconnect());
                             } else {
-                              robotProvider.connect();
+                              unawaited(robotProvider.connect());
                             }
                           },
                           child: Text(
@@ -91,8 +92,10 @@ class _ControlScreenState extends State<ControlScreen> {
                             Switch(
                               value: robotProvider.currentMode == RobotMode.automatic,
                               onChanged: (value) {
-                                robotProvider.switchMode(
-                                  value ? RobotMode.automatic : RobotMode.manual,
+                                unawaited(
+                                  robotProvider.switchMode(
+                                    value ? RobotMode.automatic : RobotMode.manual,
+                                  ),
                                 );
                               },
                             ),
@@ -160,7 +163,7 @@ class _ControlScreenState extends State<ControlScreen> {
                           max: 100,
                           divisions: 10,
                           onChanged: (value) {
-                            robotProvider.updateSpeed(value);
+                            unawaited(robotProvider.updateSpeed(value));
                           },
                         ),
                       ],
@@ -183,7 +186,7 @@ class _ControlScreenState extends State<ControlScreen> {
                         Expanded(
                           child: JoystickWidget(
                             onChanged: (x, y) {
-                              robotProvider.updateJoystick(x, y);
+                              unawaited(robotProvider.updateJoystick(x, y));
                             },
                           ),
                         ),

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,66 +1,89 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
 class ApiService {
-  // Backend URL - IMPORTANT: 
+  // Backend URL - IMPORTANT:
   // - iOS Simulator: Use 'http://localhost:3003'
   // - Android Emulator: Use 'http://10.0.2.2:3003'
   // - Physical Device: Use your computer's IP (e.g., 'http://192.168.1.100:3003')
   static const String baseUrl = 'http://localhost:3003';
-  
+
   static const String _tokenKey = 'auth_token';
   String? _token;
-  
-  // Initialize and load token from storage
+
   Future<void> init() async {
     final prefs = await SharedPreferences.getInstance();
     _token = prefs.getString(_tokenKey);
   }
-  
-  // Set the JWT token after login
+
   Future<void> setToken(String token) async {
     _token = token;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_tokenKey, token);
   }
-  
-  // Clear the token on logout
+
   Future<void> clearToken() async {
     _token = null;
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_tokenKey);
   }
-  
-  // Check if user is logged in
+
   bool get isLoggedIn => _token != null;
-  
-  // Get authorization headers
+  String? get token => _token;
+
   Map<String, String> get _headers {
-    final headers = {
+    final headers = <String, String>{
       'Content-Type': 'application/json',
     };
-    
+
     if (_token != null) {
       headers['Authorization'] = 'Bearer $_token';
     }
-    
+
     return headers;
   }
-  
-  // Auth endpoints
-  
-  /// Register a new user
-  /// POST /register
-  /// Body: { "name": string, "email": string, "password": string }
-  /// Returns: { "id": uuid, "name": string, "email": string, "role": string }
+
+  Uri _uri(String path, [Map<String, dynamic>? queryParameters]) {
+    final base = Uri.parse(baseUrl);
+    return base.replace(
+      path: path,
+      queryParameters: queryParameters?.map(
+        (key, value) => MapEntry(key, value?.toString()),
+      ),
+    );
+  }
+
+  dynamic _decodeJsonBody(http.Response response) {
+    if (response.body.isEmpty) {
+      return null;
+    }
+    return jsonDecode(response.body);
+  }
+
+  String _extractError(http.Response response, {String fallback = 'Request failed'}) {
+    final data = _decodeJsonBody(response);
+    if (data is Map<String, dynamic>) {
+      if (data['error'] is String) {
+        return data['error'] as String;
+      }
+      if (data['message'] is String) {
+        return data['message'] as String;
+      }
+    }
+    return fallback;
+  }
+
   Future<Map<String, dynamic>> register({
     required String name,
     required String email,
     required String password,
   }) async {
     final response = await http.post(
-      Uri.parse('$baseUrl/register'),
+      _uri('/register'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'name': name,
@@ -68,116 +91,169 @@ class ApiService {
         'password': password,
       }),
     );
-    
+
     if (response.statusCode == 201) {
-      return jsonDecode(response.body);
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Registration failed');
+      return _decodeJsonBody(response) as Map<String, dynamic>;
     }
+
+    throw Exception(_extractError(response, fallback: 'Registration failed'));
   }
-  
-  /// Login with email and password
-  /// POST /login
-  /// Body: { "email": string, "password": string }
-  /// Returns: { "token": string }
+
   Future<String> login({
     required String email,
     required String password,
   }) async {
     final response = await http.post(
-      Uri.parse('$baseUrl/login'),
+      _uri('/login'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'email': email,
         'password': password,
       }),
     );
-    
+
     if (response.statusCode == 200) {
-      final data = jsonDecode(response.body);
+      final data = _decodeJsonBody(response) as Map<String, dynamic>;
       final token = data['token'] as String;
-      setToken(token);
+      await setToken(token);
       return token;
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Login failed');
     }
+
+    throw Exception(_extractError(response, fallback: 'Login failed'));
   }
-  
-  /// Get current user info
-  /// GET /me
-  /// Returns: { "id": uuid, "name": string, "email": string, "role": string }
+
   Future<Map<String, dynamic>> getMe() async {
     final response = await http.get(
-      Uri.parse('$baseUrl/me'),
+      _uri('/me'),
       headers: _headers,
     );
-    
+
     if (response.statusCode == 200) {
-      return jsonDecode(response.body);
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Failed to get user info');
+      return _decodeJsonBody(response) as Map<String, dynamic>;
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to get user info'));
   }
-  
-  // Diary endpoints
-  
-  /// Get all diary entries for the authenticated user
-  /// GET /diary
-  /// Returns: Array of diary entries
-  Future<List<Map<String, dynamic>>> getDiaryEntries() async {
+
+  // Admin user management
+  Future<dynamic> getUser({String? id}) async {
     final response = await http.get(
-      Uri.parse('$baseUrl/diary'),
+      _uri('/user', id != null ? {'id': id} : null),
       headers: _headers,
     );
-    
+
     if (response.statusCode == 200) {
-      final data = jsonDecode(response.body) as List;
-      return data.cast<Map<String, dynamic>>();
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Failed to get diary entries');
+      return _decodeJsonBody(response);
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to fetch user(s)'));
   }
-  
-  /// Create a new diary entry
-  /// POST /diary
-  /// Body: { "working_minutes": int, "text": string }
-  /// Returns: Created diary entry
+
+  Future<Map<String, dynamic>> updateUser({
+    required String id,
+    String? name,
+    String? email,
+    String? role,
+  }) async {
+    final payload = <String, dynamic>{'id': id};
+    if (name != null) {
+      payload['name'] = name;
+    }
+    if (email != null) {
+      payload['email'] = email;
+    }
+    if (role != null) {
+      payload['role'] = role;
+    }
+
+    final response = await http.post(
+      _uri('/user'),
+      headers: _headers,
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode == 200) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to update user'));
+  }
+
+  Future<void> deleteUser(String id) async {
+    final response = await http.delete(
+      _uri('/user'),
+      headers: _headers,
+      body: jsonEncode({'id': id}),
+    );
+
+    if (response.statusCode == 204) {
+      return;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to delete user'));
+  }
+
+  // Diary endpoints
+  Future<List<Map<String, dynamic>>> getDiaryEntries({String? id}) async {
+    final response = await http.get(
+      _uri('/diary', id != null ? {'id': id} : null),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 200) {
+      final data = _decodeJsonBody(response);
+      if (data is List) {
+        return data.cast<Map<String, dynamic>>();
+      }
+      if (data is Map<String, dynamic>) {
+        return [data];
+      }
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to get diary entries'));
+  }
+
+  Future<List<Map<String, dynamic>>> getAllDiaryEntries() async {
+    final response = await http.get(
+      _uri('/diary/all'),
+      headers: {'Content-Type': 'application/json'},
+    );
+
+    if (response.statusCode == 200) {
+      final data = _decodeJsonBody(response) as List;
+      return data.cast<Map<String, dynamic>>();
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to get all diary entries'));
+  }
+
   Future<Map<String, dynamic>> createDiaryEntry({
     required int workingMinutes,
     required String text,
   }) async {
     final response = await http.post(
-      Uri.parse('$baseUrl/diary'),
+      _uri('/diary'),
       headers: _headers,
       body: jsonEncode({
         'working_minutes': workingMinutes,
         'text': text,
       }),
     );
-    
+
     if (response.statusCode == 201) {
-      return jsonDecode(response.body);
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Failed to create diary entry');
+      return _decodeJsonBody(response) as Map<String, dynamic>;
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to create diary entry'));
   }
-  
-  /// Update an existing diary entry
-  /// POST /diary
-  /// Body: { "id": uuid, "working_minutes": int, "text": string }
-  /// Returns: Updated diary entry
+
   Future<Map<String, dynamic>> updateDiaryEntry({
     required String id,
     required int workingMinutes,
     required String text,
   }) async {
     final response = await http.post(
-      Uri.parse('$baseUrl/diary'),
+      _uri('/diary'),
       headers: _headers,
       body: jsonEncode({
         'id': id,
@@ -185,89 +261,201 @@ class ApiService {
         'text': text,
       }),
     );
-    
+
     if (response.statusCode == 200) {
-      return jsonDecode(response.body);
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Failed to update diary entry');
+      return _decodeJsonBody(response) as Map<String, dynamic>;
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to update diary entry'));
   }
-  
-  /// Delete a diary entry
-  /// DELETE /diary
-  /// Body: { "id": uuid }
+
   Future<void> deleteDiaryEntry(String id) async {
     final response = await http.delete(
-      Uri.parse('$baseUrl/diary'),
+      _uri('/diary'),
       headers: _headers,
-      body: jsonEncode({
-        'id': id,
-      }),
+      body: jsonEncode({'id': id}),
     );
-    
-    if (response.statusCode != 204) {
-      final error = jsonDecode(response.body);
-      throw Exception(error['error'] ?? 'Failed to delete diary entry');
+
+    if (response.statusCode == 204) {
+      return;
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to delete diary entry'));
   }
-  
-  // Robot control endpoints (for future implementation)
-  
-  /// Get robot status
-  /// GET /status
-  /// Returns: Robot telemetry and status
+
+  // Robot HTTP endpoints
   Future<Map<String, dynamic>> getRobotStatus() async {
     final response = await http.get(
-      Uri.parse('$baseUrl/status'),
+      _uri('/status'),
       headers: {'Content-Type': 'application/json'},
     );
-    
+
     if (response.statusCode == 200) {
-      return jsonDecode(response.body);
-    } else {
-      throw Exception('Failed to get robot status');
+      return _decodeJsonBody(response) as Map<String, dynamic>;
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to get robot status'));
   }
-  
-  /// Get available nodes for navigation
-  /// GET /nodes
-  /// Returns: { "nodes": [string] }
+
   Future<List<String>> getNodes() async {
     final response = await http.get(
-      Uri.parse('$baseUrl/nodes'),
+      _uri('/nodes'),
       headers: _headers,
     );
-    
+
     if (response.statusCode == 200) {
-      final data = jsonDecode(response.body);
-      return (data['nodes'] as List).cast<String>();
-    } else {
-      return [];
+      final data = _decodeJsonBody(response) as Map<String, dynamic>;
+      return (data['nodes'] as List<dynamic>).cast<String>();
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to get nodes'));
   }
-  
-  /// Select a route for robot navigation
-  /// POST /routes/select
-  /// Body: { "start": string, "destination": string }
-  Future<Map<String, dynamic>> selectRoute({
+
+  Future<List<Map<String, dynamic>>> getRoutes() async {
+    final response = await http.get(
+      _uri('/routes'),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 200) {
+      final data = _decodeJsonBody(response) as List;
+      return data.cast<Map<String, dynamic>>();
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to get routes'));
+  }
+
+  Future<Map<String, dynamic>> addRoute({
     required String start,
     required String destination,
   }) async {
     final response = await http.post(
-      Uri.parse('$baseUrl/routes/select'),
+      _uri('/routes'),
       headers: _headers,
       body: jsonEncode({
         'start': start,
         'destination': destination,
       }),
     );
-    
-    if (response.statusCode == 200) {
-      return jsonDecode(response.body);
-    } else {
-      final error = jsonDecode(response.body);
-      throw Exception(error['message'] ?? 'Failed to select route');
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
     }
+
+    throw Exception(_extractError(response, fallback: 'Failed to add route'));
+  }
+
+  Future<void> deleteRoute(String id) async {
+    final response = await http.delete(
+      _uri('/routes/$id'),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 204 || response.statusCode == 200) {
+      return;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to delete route'));
+  }
+
+  Future<Map<String, dynamic>> optimizeRoutes() async {
+    final response = await http.post(
+      _uri('/routes/optimize'),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 200) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to optimize routes'));
+  }
+
+  Future<Map<String, dynamic>> selectRoute({
+    required String start,
+    required String destination,
+  }) async {
+    final response = await http.post(
+      _uri('/routes/select'),
+      headers: _headers,
+      body: jsonEncode({
+        'start': start,
+        'destination': destination,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to select route'));
+  }
+
+  Future<Map<String, dynamic>> acquireDriveLock() async {
+    final response = await http.post(
+      _uri('/drive/lock'),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 200) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to acquire lock'));
+  }
+
+  Future<Map<String, dynamic>> releaseDriveLock() async {
+    final response = await http.delete(
+      _uri('/drive/lock'),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 200) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to release lock'));
+  }
+
+  Future<Map<String, dynamic>> checkRobot() async {
+    final response = await http.get(
+      _uri('/robot/check'),
+      headers: _headers,
+    );
+
+    if (response.statusCode == 200) {
+      return _decodeJsonBody(response) as Map<String, dynamic>;
+    }
+
+    throw Exception(_extractError(response, fallback: 'Failed to check robot'));
+  }
+
+  Future<WebSocket> connectRobotControlWebSocket() async {
+    final wsUri = Uri.parse(baseUrl).replace(
+      scheme: Uri.parse(baseUrl).scheme == 'https' ? 'wss' : 'ws',
+      path: '/ws/robot/control',
+    );
+    return WebSocket.connect(wsUri.toString());
+  }
+
+  Future<WebSocket> connectManualDriveWebSocket() async {
+    if (_token == null) {
+      throw Exception('Authentication token is required');
+    }
+
+    final wsUri = Uri.parse(baseUrl).replace(
+      scheme: Uri.parse(baseUrl).scheme == 'https' ? 'wss' : 'ws',
+      path: '/ws/drive/manual',
+      queryParameters: {'token': _token},
+    );
+
+    return WebSocket.connect(wsUri.toString());
+  }
+
+  Future<void> sendManualCommand(
+    WebSocket socket,
+    Map<String, dynamic> command,
+  ) async {
+    socket.add(jsonEncode(command));
   }
 }


### PR DESCRIPTION
### Motivation
- Provide full backend integration so the Flutter app can authenticate, manage diary entries, and control the robot using the documented HTTP/WebSocket API surface.
- Replace UI-side TODOs with actual networked behavior so manual-drive locking, WebSocket-based manual control, and RBAC-aware flows work end-to-end from the client side.

### Description
- Expanded `ApiService` to implement the documented backend endpoints and helpers, including auth (`/register`, `/login`, `/me`), admin user management (`/user`), diary (`/diary`, `/diary/all`), robot endpoints (`/status`, `/nodes`, `/routes`, `/routes/optimize`, `/routes/select`, `/drive/lock`, `/robot/check`) and WebSocket helpers for `/ws/robot/control` and `/ws/drive/manual` with centralized URI/error handling (`lib/services/api_service.dart`).
- Implemented `RobotControlProvider` to acquire/release manual locks, open/close the manual-drive WebSocket, send `SET_MODE` and `DRIVE_COMMAND` payloads, expose connection/status/error state, and handle lifecycle cleanup (`lib/providers/robot_control_provider.dart`).
- Extended `AuthProvider` to persist and expose user `role` and convenience getters (`isAdmin`, `isOperator`, `isViewer`) from backend `/me` results and SharedPreferences (`lib/providers/auth_provider.dart`).
- Wired the shared `ApiService` into `RobotControlProvider` at app bootstrap and updated async calls in the control UI to call provider methods safely (`lib/main.dart`, `lib/screens/control_screen.dart`).

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues (passed).
- Attempted to run `dart format` on modified files but the `dart` CLI is not available in this environment (format step not executed).
- Attempted `flutter --version` to validate environment but the `flutter` CLI is not available in this environment (validation step not executed).
- No project unit tests were executed in this environment; changes were validated by static inspection and local codeflow wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984878436f48324a83347f10ba6ed8d)